### PR TITLE
Fix Broken Link

### DIFF
--- a/demo/main.py
+++ b/demo/main.py
@@ -14,7 +14,7 @@ def api_index() -> list[AnyComponent]:
     # language=markdown
     markdown = """\
 This site providers a demo of [FastUI](https://github.com/samuelcolvin/FastUI), the code for the demo
-is [here](https://github.com/samuelcolvin/FastUI/tree/main/python/demo).
+is [here](https://github.com/samuelcolvin/FastUI/tree/main/demo).
 
 The following components are demonstrated:
 


### PR DESCRIPTION
There is a broken link in this project. So I fixed it.

https://github.com/samuelcolvin/FastUI/tree/main/python/demo --> https://github.com/samuelcolvin/FastUI/tree/main/demo

This broken link was found with [link-inspector](https://github.com/justindhillon/link-inspector). If you find this pr useful, give the project a star ⭐

Signed off: [justin.singh.dhillon@gmail.com](mailto:justin.singh.dhillon@gmail.com)